### PR TITLE
Fix/hu 04 busca api externa

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
     id("com.google.gms.google-services")
     id("com.google.dagger.hilt.android")
     id("com.google.devtools.ksp")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,18 @@ dependencies {
     implementation("androidx.compose.material:material-icons-extended:1.7.6")
     implementation("io.coil-kt:coil-compose:2.7.0")
 
+    // Ktor Client
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.cio)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.ktor.client.logging)
+
+    // Dependências do Room
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
+
     // Firebase
     implementation(platform("com.google.firebase:firebase-bom:33.5.1"))
     implementation("com.google.firebase:firebase-auth")

--- a/app/src/main/java/com/ufc/quixada/bookworms/data/local/BookDatabase.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/data/local/BookDatabase.kt
@@ -1,0 +1,11 @@
+package com.ufc.quixada.bookworms.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.ufc.quixada.bookworms.data.local.dao.BookDao
+import com.ufc.quixada.bookworms.data.local.entity.BookEntity
+
+@Database(entities = [BookEntity::class], version = 1)
+abstract class BookDatabase: RoomDatabase() {
+    abstract val bookDao: BookDao
+}

--- a/app/src/main/java/com/ufc/quixada/bookworms/data/local/dao/BookDao.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/data/local/dao/BookDao.kt
@@ -1,0 +1,16 @@
+package com.ufc.quixada.bookworms.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.ufc.quixada.bookworms.data.local.entity.BookEntity
+
+@Dao
+interface BookDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertBook(book: BookEntity)
+
+    @Query("SELECT * FROM books WHERE bookId = :bookId")
+    suspend fun getBook(bookId: String): BookEntity?
+}

--- a/app/src/main/java/com/ufc/quixada/bookworms/data/local/entity/BookEntity.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/data/local/entity/BookEntity.kt
@@ -1,0 +1,19 @@
+package com.ufc.quixada.bookworms.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "books")
+data class BookEntity (
+    @PrimaryKey
+    val bookId: String,
+    val titulo: String,
+    val autor: String,
+    val sinopse: String,
+    val capaUrl: String?,
+    val isbn: String?,
+    val notaMediaComunidade: Float,
+    val notaApiExterna: Float?,
+    val fonteApi: String?, // "GOOGLE", "OPEN_LIBRARY"
+    val numAvaliacoes: Int,
+)

--- a/app/src/main/java/com/ufc/quixada/bookworms/data/local/entity/BookEntity.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/data/local/entity/BookEntity.kt
@@ -15,5 +15,5 @@ data class BookEntity (
     val notaMediaComunidade: Float,
     val notaApiExterna: Float?,
     val fonteApi: String?, // "GOOGLE", "OPEN_LIBRARY"
-    val numAvaliacoes: Int,
+    val numAvaliacoes: Int
 )

--- a/app/src/main/java/com/ufc/quixada/bookworms/data/remote/OpenLibraryDto.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/data/remote/OpenLibraryDto.kt
@@ -35,7 +35,7 @@ data class OpenLibraryEditionDocDto(
 )
 
 @Serializable
-data class OpenLibraryRatingResponseO(
+data class OpenLibraryRatingResponse(
     val sumary: RatingSumary? = null
 )
 

--- a/app/src/main/java/com/ufc/quixada/bookworms/data/remote/OpenLibraryDto.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/data/remote/OpenLibraryDto.kt
@@ -1,0 +1,59 @@
+package com.ufc.quixada.bookworms.data.remote
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OpenLibrarySearchResponse(
+    val docs: List<OpenLibraryDocDto> = emptyList()
+)
+
+@Serializable
+data class OpenLibraryDocDto(
+    val key: String,
+    val title: String,
+    @SerialName("author_name")
+    val authorName: List<String>? = null,
+    @SerialName("cover_i")
+    val converId: Int? = null,
+    val editions: OpenLibraryEditionsDto? = null
+)
+
+@Serializable
+data class OpenLibraryEditionsDto(
+    val docs: List<OpenLibraryEditionDocDto> = emptyList()
+)
+
+@Serializable
+data class OpenLibraryEditionDocDto(
+    val key: String,
+    val title: String,
+    val language: List<String>? = null,
+    @SerialName("cover_i")
+    val coverId: Int? = null,
+    val isbn: List<String>? = null
+)
+
+@Serializable
+data class OpenLibraryRatingResponseO(
+    val sumary: RatingSumary? = null
+)
+
+@Serializable
+data class RatingSumary(
+    val average: Float? = null
+)
+
+@Serializable
+data class OpenLibraryBookDetailsDto(
+    val description: DescriptionDto? = null, //pode ser um objeto ou string
+    @SerialName("isbn_13")
+    val isbn13: List<String>? = null,
+    @SerialName("isbn_10")
+    val isbn10: List<String>? = null
+
+)
+
+data class DescriptionDto(
+    val value: String? = null
+)

--- a/app/src/main/java/com/ufc/quixada/bookworms/data/remote/OpenLibraryDto.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/data/remote/OpenLibraryDto.kt
@@ -2,6 +2,7 @@ package com.ufc.quixada.bookworms.data.remote
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 @Serializable
 data class OpenLibrarySearchResponse(
@@ -36,24 +37,25 @@ data class OpenLibraryEditionDocDto(
 
 @Serializable
 data class OpenLibraryRatingResponse(
-    val sumary: RatingSumary? = null
+    @SerialName("summary")
+    val summary: RatingSummary? = null
 )
 
 @Serializable
-data class RatingSumary(
+data class RatingSummary(
     val average: Float? = null
 )
 
 @Serializable
 data class OpenLibraryBookDetailsDto(
-    val description: DescriptionDto? = null, //pode ser um objeto ou string
+    val description: JsonElement? = null, // Pode ser String ou Objeto
     @SerialName("isbn_13")
     val isbn13: List<String>? = null,
     @SerialName("isbn_10")
     val isbn10: List<String>? = null
-
 )
 
+@Serializable
 data class DescriptionDto(
     val value: String? = null
 )

--- a/app/src/main/java/com/ufc/quixada/bookworms/data/remote/OpenLibraryDto.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/data/remote/OpenLibraryDto.kt
@@ -16,7 +16,7 @@ data class OpenLibraryDocDto(
     @SerialName("author_name")
     val authorName: List<String>? = null,
     @SerialName("cover_i")
-    val converId: Int? = null,
+    val coverId: Int? = null,
     val editions: OpenLibraryEditionsDto? = null
 )
 

--- a/app/src/main/java/com/ufc/quixada/bookworms/data/repository/OpenLibraryRepositoryImpl.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/data/repository/OpenLibraryRepositoryImpl.kt
@@ -1,0 +1,61 @@
+package com.ufc.quixada.bookworms.data.repository
+
+import com.ufc.quixada.bookworms.data.remote.OpenLibrarySearchResponse
+import com.ufc.quixada.bookworms.domain.model.Book
+import com.ufc.quixada.bookworms.domain.repository.OpenLibraryRepository
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import javax.inject.Inject
+
+class OpenLibraryRepositoryImpl @Inject constructor(
+    private val client: HttpClient
+): OpenLibraryRepository {
+    private val apiBase = "https://openlibrary.org/search.json"
+    private val detailsBase = "https://openlibrary.org" // /books/ or /works/
+
+    override suspend fun searchBooks(query: String): Result<List<Book>> {
+        return try {
+            val response: OpenLibrarySearchResponse = client.get(apiBase) {
+                parameter("q", "title:($query) AND language:por")
+                parameter("fields", "key,title,author_name,cover_i,editions,editions.title,editions.language,editions.cover_i,editions.key,editions.isbn")
+                parameter("limit", 12)
+            }.body()
+
+            val books = response.docs.mapNotNull { doc ->
+                val ptEditions = doc.editions?.docs?.filter {
+                    it.language?.any { lang -> lang.contains("por") } == true
+                } ?: emptyList()
+
+                if (ptEditions.isEmpty()) return@mapNotNull null
+
+                val bestEdition = ptEditions.maxByOrNull { it.coverId != null }!!
+                Book(
+                    bookId = bestEdition.key,
+                    titulo = bestEdition.title,
+                    autor = doc.authorName?.joinToString(", ") ?: "Autor Desconhecido",
+                    capaUrl = getCoverUrl(bestEdition.coverId ?: doc.converId),
+                    fonteApi = "OpenLibrary",
+                    isbn = bestEdition.isbn?.firstOrNull()
+                )
+            }
+            Result.success(books)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getBookDetails(
+        workKey: String,
+        editionKey: String?
+    ): Result<Book> {
+        TODO("Not yet implemented")
+    }
+
+    private fun getCoverUrl(coverId: Int?): String? {
+        return coverId?.let { "https://covers.openlibrary.org/b/id/$it-L.jpg" }
+    }
+
+}

--- a/app/src/main/java/com/ufc/quixada/bookworms/data/repository/OpenLibraryRepositoryImpl.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/data/repository/OpenLibraryRepositoryImpl.kt
@@ -39,14 +39,14 @@ class OpenLibraryRepositoryImpl @Inject constructor(
                 val finalIsbn: String?
 
                 if (ptEditions.isNotEmpty()) {
-                    val bestEdition = ptEditions.maxByOrNull { it.coverId != null }!!
+                    val bestEdition = ptEditions.maxByOrNull { it.coverId != null } ?: ptEditions.first()
                     finalTitle = bestEdition.title
                     finalCoverId = bestEdition.coverId
                     finalKey = bestEdition.key
                     finalIsbn = bestEdition.isbn?.firstOrNull()
                 } else {
                     finalTitle = doc.title
-                    finalCoverId = doc.converId
+                    finalCoverId = doc.coverId
                     finalKey = doc.key
                     val bestAnyEdition = doc.editions?.docs?.maxByOrNull { it.coverId != null }
                     finalIsbn = bestAnyEdition?.isbn?.firstOrNull()
@@ -74,7 +74,7 @@ class OpenLibraryRepositoryImpl @Inject constructor(
             val endpoint = if (isWork) "works" else "books"
 
             //busca avaliações
-            val rattingsDeferred = async {
+            val ratingsDeferred = async {
                 try {
                     client.get("$detailsBase/works/$bookId/ratings.json").body<OpenLibraryRatingResponse>()
                 } catch (e: Exception) { null }
@@ -87,7 +87,7 @@ class OpenLibraryRepositoryImpl @Inject constructor(
                 } catch (e: Exception) { null }
             }
 
-            val ratings = rattingsDeferred.await()
+            val ratings = ratingsDeferred.await()
             val details = detailsDeferred.await()
 
             //parse da descrição

--- a/app/src/main/java/com/ufc/quixada/bookworms/di/AppModule.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/di/AppModule.kt
@@ -1,7 +1,11 @@
 package com.ufc.quixada.bookworms.di
 
+import android.content.Context
+import androidx.room.Room
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.ufc.quixada.bookworms.data.local.BookDatabase
+import com.ufc.quixada.bookworms.data.local.dao.BookDao
 import com.ufc.quixada.bookworms.data.repository.AuthRepositoryImpl
 import com.ufc.quixada.bookworms.data.repository.BookRepositoryImpl
 import com.ufc.quixada.bookworms.data.repository.FavoriteRepositoryImpl
@@ -15,6 +19,7 @@ import com.ufc.quixada.bookworms.domain.repository.UserRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
@@ -53,9 +58,10 @@ object AppModule {
     @Provides
     @Singleton
     fun provideBookRepository(
-        firestore: FirebaseFirestore
+        firestore: FirebaseFirestore,
+        bookDao: BookDao
     ): BookRepository {
-        return BookRepositoryImpl(firestore)
+        return BookRepositoryImpl(firestore, bookDao)
     }
 
     @Provides
@@ -98,5 +104,21 @@ object AppModule {
                 })
             }
         }
+    }
+
+    @Provides
+    @Singleton
+    fun provideBookDatabase(@ApplicationContext context: Context): BookDatabase {
+        return Room.databaseBuilder(
+            context,
+            BookDatabase::class.java,
+            "bookworms_db"
+        ).build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideBookDao(database: BookDatabase): BookDao {
+        return database.bookDao
     }
 }

--- a/app/src/main/java/com/ufc/quixada/bookworms/di/AppModule.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/di/AppModule.kt
@@ -5,10 +5,12 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.ufc.quixada.bookworms.data.repository.AuthRepositoryImpl
 import com.ufc.quixada.bookworms.data.repository.BookRepositoryImpl
 import com.ufc.quixada.bookworms.data.repository.FavoriteRepositoryImpl
+import com.ufc.quixada.bookworms.data.repository.OpenLibraryRepositoryImpl
 import com.ufc.quixada.bookworms.data.repository.UserRepositoryImpl
 import com.ufc.quixada.bookworms.domain.repository.AuthRepository
 import com.ufc.quixada.bookworms.domain.repository.BookRepository
 import com.ufc.quixada.bookworms.domain.repository.FavoriteRepository
+import com.ufc.quixada.bookworms.domain.repository.OpenLibraryRepository
 import com.ufc.quixada.bookworms.domain.repository.UserRepository
 import dagger.Module
 import dagger.Provides
@@ -70,6 +72,14 @@ object AppModule {
         firestore: FirebaseFirestore
     ): FavoriteRepository {
         return FavoriteRepositoryImpl(firestore)
+    }
+
+    @Provides
+    @Singleton
+    fun provideOpenLibraryRepository(
+        client: HttpClient
+    ): OpenLibraryRepository {
+        return OpenLibraryRepositoryImpl(client)
     }
 
     @Provides

--- a/app/src/main/java/com/ufc/quixada/bookworms/di/AppModule.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/di/AppModule.kt
@@ -14,6 +14,13 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
 import javax.inject.Singleton
 
 @Module
@@ -63,5 +70,23 @@ object AppModule {
         firestore: FirebaseFirestore
     ): FavoriteRepository {
         return FavoriteRepositoryImpl(firestore)
+    }
+
+    @Provides
+    @Singleton
+    fun provideHttpClient(): HttpClient {
+        return HttpClient(CIO) {
+            install(Logging) { //logging plugin
+                level = LogLevel.ALL
+            }
+
+            install(ContentNegotiation) { // JSON serialization/deserialization
+                json(Json{
+                    prettyPrint = true
+                    isLenient = true
+                    ignoreUnknownKeys = true
+                })
+            }
+        }
     }
 }

--- a/app/src/main/java/com/ufc/quixada/bookworms/di/AppModule.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/di/AppModule.kt
@@ -97,7 +97,7 @@ object AppModule {
             }
 
             install(ContentNegotiation) { // JSON serialization/deserialization
-                json(Json{
+                json(Json {
                     prettyPrint = true
                     isLenient = true
                     ignoreUnknownKeys = true

--- a/app/src/main/java/com/ufc/quixada/bookworms/domain/repository/BookRepository.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/domain/repository/BookRepository.kt
@@ -16,4 +16,5 @@ interface BookRepository {
     suspend fun getBooks(): BookResult
     suspend fun getBook(bookId: String): SingleBookResult
     suspend fun searchBooks(query: String): BookResult
+    suspend fun saveBook(book: Book)
 }

--- a/app/src/main/java/com/ufc/quixada/bookworms/domain/repository/OpenLibraryRepository.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/domain/repository/OpenLibraryRepository.kt
@@ -4,5 +4,5 @@ import com.ufc.quixada.bookworms.domain.model.Book
 
 interface OpenLibraryRepository {
     suspend fun searchBooks(query: String): BookResult
-    suspend fun getBookDetails(workKey: String, editionKey: String?): Result<Book>
+    suspend fun getBookDetails(bookId: String): Result<Book>
 }

--- a/app/src/main/java/com/ufc/quixada/bookworms/domain/repository/OpenLibraryRepository.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/domain/repository/OpenLibraryRepository.kt
@@ -3,6 +3,6 @@ package com.ufc.quixada.bookworms.domain.repository
 import com.ufc.quixada.bookworms.domain.model.Book
 
 interface OpenLibraryRepository {
-    suspend fun searchBooks(query: String): Result<List<Book>>
+    suspend fun searchBooks(query: String): BookResult
     suspend fun getBookDetails(workKey: String, editionKey: String?): Result<Book>
 }

--- a/app/src/main/java/com/ufc/quixada/bookworms/domain/repository/OpenLibraryRepository.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/domain/repository/OpenLibraryRepository.kt
@@ -1,0 +1,8 @@
+package com.ufc.quixada.bookworms.domain.repository
+
+import com.ufc.quixada.bookworms.domain.model.Book
+
+interface OpenLibraryRepository {
+    suspend fun searchBooks(query: String): Result<List<Book>>
+    suspend fun getBookDetails(workKey: String, editionKey: String?): Result<Book>
+}

--- a/app/src/main/java/com/ufc/quixada/bookworms/domain/usecase/GetBookDetailsUseCase.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/domain/usecase/GetBookDetailsUseCase.kt
@@ -1,13 +1,40 @@
 package com.ufc.quixada.bookworms.domain.usecase
 
 import com.ufc.quixada.bookworms.domain.repository.BookRepository
+import com.ufc.quixada.bookworms.domain.repository.OpenLibraryRepository
 import com.ufc.quixada.bookworms.domain.repository.SingleBookResult
 import javax.inject.Inject
 
 class GetBookDetailsUseCase @Inject constructor(
-    private val bookRepository: BookRepository
+    private val bookRepository: BookRepository,
+    private val openLibraryRepository: OpenLibraryRepository
 ) {
     suspend operator fun invoke(bookId: String): SingleBookResult {
-        return bookRepository.getBook(bookId)
+        val result = bookRepository.getBook(bookId)
+
+        if (result is SingleBookResult.Success) {
+            val book = result.data
+
+            if (book.sinopse.isNotBlank()) {
+                return result
+            }
+
+            val apiResult = openLibraryRepository.getBookDetails(bookId)
+
+            if (apiResult.isSuccess) {
+                val apiDetails = apiResult.getOrThrow()
+
+                val updatedBook = book.copy(
+                    sinopse = apiDetails.sinopse,
+                    notaApiExterna = apiDetails.notaApiExterna ?: book.notaApiExterna,
+                    isbn = apiDetails.isbn ?: book.isbn
+                )
+
+                bookRepository.saveBook(updatedBook)
+                return SingleBookResult.Success(updatedBook)
+            }
+        }
+
+        return result
     }
 }

--- a/app/src/main/java/com/ufc/quixada/bookworms/domain/usecase/SaveBookUseCase.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/domain/usecase/SaveBookUseCase.kt
@@ -1,0 +1,13 @@
+package com.ufc.quixada.bookworms.domain.usecase
+
+import com.ufc.quixada.bookworms.domain.model.Book
+import com.ufc.quixada.bookworms.domain.repository.BookRepository
+import javax.inject.Inject
+
+class SaveBookUseCase @Inject constructor(
+    private val repository: BookRepository
+) {
+    suspend operator fun invoke(book: Book) {
+        repository.saveBook(book)
+    }
+}

--- a/app/src/main/java/com/ufc/quixada/bookworms/domain/usecase/SearchBooksUseCase.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/domain/usecase/SearchBooksUseCase.kt
@@ -2,15 +2,30 @@ package com.ufc.quixada.bookworms.domain.usecase
 
 import com.ufc.quixada.bookworms.domain.repository.BookRepository
 import com.ufc.quixada.bookworms.domain.repository.BookResult
+import com.ufc.quixada.bookworms.domain.repository.OpenLibraryRepository
 import javax.inject.Inject
 
 class SearchBooksUseCase @Inject constructor(
-    private val bookRepository: BookRepository
+    private val bookRepository: BookRepository,
+    private val openLibraryRepository: OpenLibraryRepository
 ) {
     suspend operator fun invoke(query: String): BookResult {
         if (query.isBlank()) {
             return bookRepository.getBooks()
         }
-        return bookRepository.searchBooks(query)
+        
+        val localResult = bookRepository.searchBooks(query)
+        val localBooks = if (localResult is BookResult.Success) localResult.data else emptyList()
+
+        val apiResult = openLibraryRepository.searchBooks(query)
+        val apiBooks = if (apiResult is BookResult.Success) apiResult.data else emptyList()
+
+        val allBooks = (localBooks + apiBooks).distinctBy { it.bookId }
+
+        return if (allBooks.isNotEmpty()) {
+            BookResult.Success(allBooks)
+        } else {
+            apiResult as? BookResult.Error ?: BookResult.Error("Nenhum livro encontrado.")
+        }
     }
 }

--- a/app/src/main/java/com/ufc/quixada/bookworms/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/presentation/home/HomeScreen.kt
@@ -58,8 +58,7 @@ fun HomeScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
 
-    Scaffold(
-    ) { paddingValues ->
+    Scaffold { paddingValues ->
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/ufc/quixada/bookworms/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/presentation/home/HomeScreen.kt
@@ -131,7 +131,11 @@ fun HomeScreen(
                                 BookItem(
                                     book = book,
                                     isFavorite = uiState.favoriteBookIds.contains(book.bookId), // Verifica favorito
-                                    onClick = { onBookClick(book.bookId) }
+                                    onClick = {
+                                        viewModel.onBookSelected(book) { id ->
+                                            onBookClick(id)
+                                        }
+                                    }
                                 )
                             }
                         }

--- a/app/src/main/java/com/ufc/quixada/bookworms/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/presentation/home/HomeViewModel.kt
@@ -50,9 +50,7 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, errorMessage = null) }
 
-            val bookResult = getBooksUseCase()
-
-            when (bookResult) {
+            when (val bookResult = getBooksUseCase()) {
                 is BookResult.Success -> {
                     _uiState.update {
                         it.copy(isLoading = false, books = bookResult.data)
@@ -80,10 +78,7 @@ class HomeViewModel @Inject constructor(
     private suspend fun performSearch(query: String) {
         _uiState.update { it.copy(isLoading = true, errorMessage = null) }
 
-        val result = searchBooksUseCase(query)
-
-
-        when (result) {
+        when (val result = searchBooksUseCase(query)) {
             is BookResult.Success -> {
                 _uiState.update { it.copy(isLoading = false, books = result.data) }
             }

--- a/app/src/main/java/com/ufc/quixada/bookworms/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ufc/quixada/bookworms/presentation/home/HomeViewModel.kt
@@ -2,9 +2,11 @@ package com.ufc.quixada.bookworms.presentation.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ufc.quixada.bookworms.domain.model.Book
 import com.ufc.quixada.bookworms.domain.repository.BookResult
 import com.ufc.quixada.bookworms.domain.usecase.GetBooksUseCase
 import com.ufc.quixada.bookworms.domain.usecase.ManageFavoriteUseCase
+import com.ufc.quixada.bookworms.domain.usecase.SaveBookUseCase
 import com.ufc.quixada.bookworms.domain.usecase.SearchBooksUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
@@ -20,7 +22,8 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val getBooksUseCase: GetBooksUseCase,
     private val searchBooksUseCase: SearchBooksUseCase,
-    private val manageFavoriteUseCase: ManageFavoriteUseCase
+    private val manageFavoriteUseCase: ManageFavoriteUseCase,
+    private val saveBookUseCase: SaveBookUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(HomeUiState())
@@ -72,6 +75,13 @@ class HomeViewModel @Inject constructor(
         searchJob = viewModelScope.launch {
             delay(500)
             performSearch(newQuery)
+        }
+    }
+
+    fun onBookSelected(book: Book, navigate: (String) -> Unit) {
+        viewModelScope.launch {
+            saveBookUseCase(book)
+            navigate(book.bookId)
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ activityCompose = "1.10.1"
 composeBom = "2024.09.00"
 hilt = "2.51.1"
 hiltExt = "1.2.0"
-ktor = "3.3.3"
+ktor = "3.0.1"
 kotlinxSerialization = "2.0.21"
 room = "2.8.4"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,9 @@ activityCompose = "1.10.1"
 composeBom = "2024.09.00"
 hilt = "2.51.1"
 hiltExt = "1.2.0"
+ktor = "3.3.3"
+kotlinxSerialization = "2.0.21"
+room = "2.8.4"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -29,9 +32,18 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltExt" }
 google-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 google-hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
+ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
+ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
+ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinxSerialization" }


### PR DESCRIPTION
Esta pull request introduz melhorias significativas na camada de dados de livros, integrando o armazenamento local com Room e a busca de dados remotos da API do Open Library usando Ktor. Também atualiza a configuração de injeção de dependência para suportar esses novos recursos e aprimora a lógica de busca e recuperação de detalhes de livros ao combinar fontes locais e remotas. As mudanças mais importantes estão agrupadas abaixo:

**Armazenamento de Dados Local com Room:**

* Adicionados `BookEntity`, `BookDao` e `BookDatabase` para permitir o armazenamento e recuperação local de dados de livros usando Room. (`app/src/main/java/com/ufc/quixada/bookworms/data/local/entity/BookEntity.kt` [[1]](diffhunk://#diff-f2cccf2cb9188776e303ad95cf3833ff6317538171be69752d03313b7fc49a98R1-R19) `app/src/main/java/com/ufc/quixada/bookworms/data/local/dao/BookDao.kt` [[2]](diffhunk://#diff-0b4bf8b8ff85b52e5b3dc2b6263f57aebadf4e2eaaf7f632a52ba1bbb4c55092R1-R16) `app/src/main/java/com/ufc/quixada/bookworms/data/local/BookDatabase.kt` [[3]](diffhunk://#diff-e2db1d80fe8a3f9e0c758cdc6cf5575ee44d0489c13904c17bd3857602c15256R1-R11)
* Atualizado `BookRepositoryImpl` para verificar o banco de dados local antes de consultar o Firestore e para salvar livros tanto localmente quanto remotamente. (`app/src/main/java/com/ufc/quixada/bookworms/data/repository/BookRepositoryImpl.kt` [[1]](diffhunk://#diff-14ef329c132d09641fd82fbe1ac27a627e96de465d3e37acea15f78d7fa02a23L12-R15) [[2]](diffhunk://#diff-14ef329c132d09641fd82fbe1ac27a627e96de465d3e37acea15f78d7fa02a23R37-R41) [[3]](diffhunk://#diff-14ef329c132d09641fd82fbe1ac27a627e96de465d3e37acea15f78d7fa02a23R77-R114)
* Registrados os componentes do Room no módulo de injeção de dependência. (`app/src/main/java/com/ufc/quixada/bookworms/di/AppModule.kt` [[1]](diffhunk://#diff-90654b408dda82f1ccbafa492f8bfe79005159f607df60a2154fa401ca3989e8R3-R30) [[2]](diffhunk://#diff-90654b408dda82f1ccbafa492f8bfe79005159f607df60a2154fa401ca3989e8R82-R123)

**Integração com a API do Open Library:**

* Adicionados DTOs para as respostas da API do Open Library e implementado `OpenLibraryRepositoryImpl` para lidar com a busca de livros e detalhes via cliente Ktor. (`app/src/main/java/com/ufc/quixada/bookworms/data/remote/OpenLibraryDto.kt` [[1]](diffhunk://#diff-3483c852e147a1ba467e134cd02fd3af8a2293054a0b8faca2e16476675c38deR1-R61) `app/src/main/java/com/ufc/quixada/bookworms/data/repository/OpenLibraryRepositoryImpl.kt` [[2]](diffhunk://#diff-651232a8cf408d0d2908387d2e093eb42e8c77764cc5e6a4271c898d78ad4999R1-R118)
* Definida a interface `OpenLibraryRepository` e registrada sua implementação no DI (Injeção de Dependência). (`app/src/main/java/com/ufc/quixada/bookworms/domain/repository/OpenLibraryRepository.kt` [[1]](diffhunk://#diff-c29498042f465291077e94cfaf5287087e190d7dade9853d8cf722e86f542baeR1-R8) `app/src/main/java/com/ufc/quixada/bookworms/di/AppModule.kt` [[2]](diffhunk://#diff-90654b408dda82f1ccbafa492f8bfe79005159f607df60a2154fa401ca3989e8R82-R123)
* Adicionadas dependências do cliente Ktor e plugin de serialização. (`app/build.gradle.kts` [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R5) [[2]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R61-R72) [[3]](diffhunk://#diff-90654b408dda82f1ccbafa492f8bfe79005159f607df60a2154fa401ca3989e8R3-R30) [[4]](diffhunk://#diff-90654b408dda82f1ccbafa492f8bfe79005159f607df60a2154fa401ca3989e8R82-R123)

**Melhorias na Lógica de Busca e Detalhes do Livro:**

* Aprimorado o `SearchBooksUseCase` para combinar resultados do banco de dados local e da API do Open Library, removendo duplicatas. (`app/src/main/java/com/ufc/quixada/bookworms/domain/usecase/SearchBooksUseCase.kt` [app/src/main/java/com/ufc/quixada/bookworms/domain/usecase/SearchBooksUseCase.ktR5-R29](diffhunk://#diff-98d0756166f888df78fa5bee2ae788250b28f63068bd242640b95db801e933beR5-R29))
* Atualizado o `GetBookDetailsUseCase` para buscar e mesclar detalhes ausentes do Open Library quando não estiverem disponíveis localmente, salvando os dados enriquecidos. (`app/src/main/java/com/ufc/quixada/bookworms/domain/usecase/GetBookDetailsUseCase.kt` [app/src/main/java/com/ufc/quixada/bookworms/domain/usecase/GetBookDetailsUseCase.ktR4-R38](diffhunk://#diff-04cf45ca63562c832b71be88ebf3c0e081ccf2adfc57b0b0f2a3f98627293314R4-R38))
* Adicionado `SaveBookUseCase` para salvar livros através da abstração do repositório. (`app/src/main/java/com/ufc/quixada/bookworms/domain/usecase/SaveBookUseCase.kt` [app/src/main/java/com/ufc/quixada/bookworms/domain/usecase/SaveBookUseCase.ktR1-R13](diffhunk://#diff-56e3cff455593eaf4228237f71a9a3a95d57463accd7cec91bb75a63f04ff1cbR1-R13))

**Injeção de Dependência e Configuração do Gradle:**

* Registradas novas dependências e plugins para Room, Ktor e serialização no Gradle e no módulo de DI. (`app/build.gradle.kts` [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R5) [[2]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R61-R72) `app/src/main/java/com/ufc/quixada/bookworms/di/AppModule.kt` [[3]](diffhunk://#diff-90654b408dda82f1ccbafa492f8bfe79005159f607df60a2154fa401ca3989e8R3-R30) [[4]](diffhunk://#diff-90654b408dda82f1ccbafa492f8bfe79005159f607df60a2154fa401ca3989e8L47-R64) [[5]](diffhunk://#diff-90654b408dda82f1ccbafa492f8bfe79005159f607df60a2154fa401ca3989e8R82-R123)

**Atualizações na Interface do Repositório:**

* Adicionado o método `saveBook` à interface `BookRepository` para suportar o salvamento de livros de diversas fontes. (`app/src/main/java/com/ufc/quixada/bookworms/domain/repository/BookRepository.kt` [app/src/main/java/com/ufc/quixada/bookworms/domain/repository/BookRepository.ktR19](diffhunk://#diff-bc47f1807e4c642de6095fdfe67c2c3dfefb7e0012cbf9509246a52e9dfe49faR19))

Essas mudanças coletivamente permitem que o aplicativo armazene e recupere dados de livros tanto localmente quanto remotamente, mescle e enriqueça informações de livros de múltiplas fontes e garanta um gerenciamento de dependências robusto para esses recursos.